### PR TITLE
Fixes context filter priority

### DIFF
--- a/clarkson-404.php
+++ b/clarkson-404.php
@@ -24,7 +24,7 @@ class FourOFour {
 
     protected function __construct() {
         add_action( 'admin_init', array( $this, 'settings_field' ) );
-        add_filter( 'clarkson_core_template_context', array( $this, 'add_404_object' ) );
+        add_filter( 'clarkson_core_template_context', array( $this, 'add_404_object' ), 11 );
         add_action( 'wp', array( $this, 'force_404' ) );
     }
 


### PR DESCRIPTION
the object was not correctly filled. Normally the order in which actions where added into `clarkson_core_template_context` (or `clarkson_context_args` would be correct, but since v1.0.0 of Clarkson Core, the 404 plugin hook would run before Clarkson Core sets it variables.

This change makes it explicit that the 404 metadata is only added after Clarkson Core has done it's thing.