### PR TITLE
Fix unavailable 404 page.

### DIFF
--- a/clarkson-404.php
+++ b/clarkson-404.php
@@ -66,7 +66,11 @@ class FourOFour {
 
 		$object_loader = Objects::get_instance();
 
-		$page = $object_loader->get_object( $id );
+		try {
+			$page = $object_loader->get_object( $id );
+		} catch ( \Exception $e ) {
+			return $objects;
+		}
 
 		$objects['objects'] = array( $page );
 


### PR DESCRIPTION
Fixes issue with set 404 ID that can not be loaded. Error was an uncaught "Uncaught Exception TypeError: "Clarkson_Core\Objects::get_object(): Argument #1 ($post) must be of type WP_Post, null given, called in /srv/http/shared/deploys/releases/20231115101209/mu-plugins/clarkson-404/clarkson-404.php on line 69"